### PR TITLE
Access localStorage inside try block

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -304,9 +304,10 @@
   }
 
   function loadLegacyConfig() {
-    var config = localStorage.getItem('flo-config');
-    localStorage.removeItem('flo-config');
+    var config;
     try {
+      config = localStorage.getItem('flo-config');
+      localStorage.removeItem('flo-config');
       return JSON.parse(config);
     } catch (e) {}
   }


### PR DESCRIPTION
Accessing the `localStorage` property in the Chrome extension throws an error (when you are blocking third-party cookies) causing the extension not to load. Accessing it within the try block fixes it. Possibly solves #6 
