### PR TITLE
Fixed Server Tests to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "sane": "~0.4.0"
   },
   "devDependencies": {
+    "mkdirp": "^0.5.0",
     "mocha": "~1.17.1"
   },
   "bin": "./bin/flo"


### PR DESCRIPTION
I was going to take a look at the windows issues but the server unit tests did not pass because of path/directory issues on windows

I changed the mkdir calls to mkdirp which is a recursive directory creation module which was added to the devDependencies in package.json

I also changed the way the testDir was defined and combined, in short I used 

path.resolve(.. 
path.join( 

To make it x-compatible 

I also changed it to resolve to ./ so it was in the same directory instead of the root.  On the newer versions of windows this can cause security issues if you are not running with admin privileges

Units now pass on windows and linux, not at work so can't check a mac ( but should be good )  

NOTE: Running npm test will also not work on windows because of the / vs \ issue, I would suggest adding another entry into script 

e.g.

```
"scripts": {
    "test": "node_modules/mocha/bin/mocha ./test/**/*_test.js --bail",
    "wtest": "node_modules\.bin\mocha .\test\**\*_test.js --bail"
  }
```

Then windows types can type npm run wtest vs. npm test, I did not do this last bit since I was not sure what your thoughts were on this. 
