### PR TITLE
On windows, the file path contains back slashes

### DIFF
--- a/lib/flo.js
+++ b/lib/flo.js
@@ -174,7 +174,7 @@ function normalizeResource(resource) {
 
   ret.match = resource.match || 'indexOf';
   ret.contents = resource.contents.toString();
-  ret.resourceURL = resource.resourceURL;
+  ret.resourceURL = resource.resourceURL.replace(/\\/g, '/');
 
   assert.ok(
     isRegExp(ret.match) ||


### PR DESCRIPTION
Ensure that resourceURL is transformed to replace back slashes with forward slashes
