### PR TITLE
File watcher throws errors sometimes, now Flo handles them

### DIFF
--- a/lib/flo.js
+++ b/lib/flo.js
@@ -172,7 +172,7 @@ function normalizeResource(resource) {
 
   ret.match = resource.match || 'indexOf';
   ret.contents = resource.contents.toString();
-  ret.resourceURL = resource.resourceURL.replace(/\\/g, '/');
+  ret.resourceURL = resource.resourceURL;
 
   if (path.sep === '\\') {
     ret.resourceURL = ret.resourceURL.replace(/\\/g, '/');


### PR DESCRIPTION
I was experiencing some odd errors coming out of the file watcher I didn't understand. I added this handler to prevent Flo from crashing as these errors from Watcher didnt appear to impact on the application's behavior.
