### PR TITLE
accept server instance as an option, so it may intergrate with other app...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ var server = flo(
 );
 ```
 
+or integrate with exist server instance:
+
+```
+var express = require('express'),
+  app = express(),
+  http = require("http"),
+  server = http.createServer(app),
+  fs = require('fs')
+
+flo(PATH_TO_DIR,{
+    server:server,
+    glob:[
+      '**/*.css',
+      '**/*.html',
+      '**/*.jade'
+    ]},function( filePath, callback){
+      callback({
+        resourceURL : resourceURL,
+        contents : fs.readFileSync(path.join(root,filePath)),
+        update : function( _window,_resourceURL){
+        }
+      })
+    }
+  })
+```
+
 `flo` takes the following arguments.
 
 * `sourceDirToWatch`: absolute or relative path to the directory to watch that contains the source code that will be built.

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -74,6 +74,7 @@ function Flo(dir, options, callback) {
   this.realpathdir = fs.realpathSync(dir);
   this.resolver = callback;
   this.server = new Server({
+    server : options.server || null,
     port: options.port,
     host: options.host,
     log: logger(options.verbose, 'Server')

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -68,7 +68,7 @@ var DELAY = 200;
  * @private
  */
 
-function Flo(dir, options, callback) {
+function Flo( dir, options, callback) {
   this.log = logger(options.verbose, 'Flo');
   this.dir = dir;
   this.realpathdir = fs.realpathSync(dir);

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,11 +24,11 @@ module.exports = Server;
 
 function Server(options) {
   this.log = options.log || function() {};
-  this.httpServer = http.createServer(function(req, res) {
+  this.httpServer = options.server || http.createServer(function(req, res) {
     res.writeHead(404);
     res.end();
   });
-  this.httpServer.listen(options.port);
+  !options.server && this.httpServer.listen(options.port);
   this.wsServer = new WSS({
     httpServer: this.httpServer,
     autoAcceptConnections: false

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "fb-flo",
+  "name": "fb-flo-extra",
   "version": "0.3.1",
   "description": "Modify running web apps without reloading",
   "repository": {
     "type": "git",
-    "url": "git@github.com:facebook/fb-flo.git"
+    "url": "git@github.com:sskyy/fb-flo.git"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
with this pr, you can use it with express like : 

```
var express = require('express'),
  app = express(),
  http = require("http"),
  server = http.createServer(app)

flo(PATH_TO_DIR,{
    server:server,
    glob:[
      '**/*.css',
      '**/*.html',
      '**/*.jade'
    ]},function( filepath, callback){

      callback({
        resourceURL : resourceURL,
        contents : fs.readFileSync(path.join(root,filepath)),
        update : function( _window,_resourceURL){
        }
      })
    }
  })
```
