### PR TITLE
Update sane to 1.0.0-rc1

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ var server = flo(
     * `host` to listen on.
     * `verbose` `true` or `false` value indicating if flo should be noisy.
     * `glob` a glob string or array of globs to match against the files to watch.
+    * `useWatchman` when watching a large number of folders or where watching is buggy you can use (watchman)[https://facebook.github.io/watchman/].
     * `useFilePolling` some platforms that do not support native file watching, you can force the file watcher to work in polling mode.
     * `pollingInterval` if in polling mode (useFilePolling) then you can set the interval (in milliseconds) at which to poll for file changes.
+    * `watchDotFiles` dot files are not watched by default.
 * `resolver` a function to map between files and resources.
 
 The resolver callback is called with two arguments:

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -42,8 +42,10 @@ function flo(dir, options, callback) {
     host: options.host || 'localhost',
     verbose: options.verbose || false,
     glob: options.glob || [],
+    useWatchman: options.useWatchman || false,
     useFilePolling: options.useFilePolling || false,
-    pollingInterval: options.pollingInterval
+    pollingInterval: options.pollingInterval,
+    watchDotFiles: options.watchDotFiles || false
   };
 
   callback = callback || noBuildCallback(dir);
@@ -79,10 +81,12 @@ function Flo(dir, options, callback) {
     log: logger(options.verbose, 'Server')
   });
 
-  this.watcher = new sane.Watcher(dir, {
+  this.watcher = new sane(dir, {
     glob: options.glob,
     poll: options.useFilePolling,
-    pollingInterval: options.pollingInterval
+    interval: options.pollingInterval,
+    watchman: options.useWatchman,
+    dot: options.watchDotFiles
   });
   this.watcher.on('change', this.onFileChange.bind(this));
   this.watcher.on('ready', this.emit.bind(this, 'ready'));

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "BSD-2-Clause",
   "dependencies": {
     "websocket": "~1.0.8",
-    "sane": "~0.7.1"
+    "sane": "~1.0.0-rc1"
   },
   "devDependencies": {
     "mocha": "~1.17.1"


### PR DESCRIPTION
We recently ran into issues with node watching a large directory and `watchman` seems to sort this out. Updating sane and the options api.
