### PR TITLE
Honour the 'host' option.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,7 +28,7 @@ function Server(options) {
     res.writeHead(404);
     res.end();
   });
-  this.httpServer.listen(options.port);
+  this.httpServer.listen(options.port, options.host);
   this.wsServer = new WSS({
     httpServer: this.httpServer,
     autoAcceptConnections: false


### PR DESCRIPTION
Currently, fb-flo always binds on 0.0.0.0 (the wildcard pseudo IP address) for me, no matter the `host` setting. I could not find any place that uses options.host, so I added the argument to `httpServer.listen`. Looking at the output of `netstat -ltn`, we now listen on the correct host.

The bug seems to have existed since the initial commit in [0516f43](https://github.com/facebook/fb-flo/commit/0516f43ad6225146a69a9bc3370022107232e6eb#diff-c945a46d13b34fcaff544d966cffcabaR21).
