### PR TITLE
Make starting a watcher optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ var server = flo(
     * `useFilePolling` some platforms that do not support native file watching, you can force the file watcher to work in polling mode.
     * `pollingInterval` if in polling mode (useFilePolling) then you can set the interval (in milliseconds) at which to poll for file changes.
     * `watchDotFiles` dot files are not watched by default.
+    * `disableWatcher` set to true to disable starting a watcher (if you want to integrate with your own watcher)
 * `resolver` a function to map between files and resources.
 
 The resolver callback is called with two arguments:

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -91,8 +91,6 @@ function Flo(dir, options, callback) {
     this.watcher.on('change', this.onFileChange.bind(this));
     this.watcher.on('ready', this.emit.bind(this, 'ready'));
     this.watcher.on('error', this.emit.bind(this, 'error'));
-  } else {
-    this.emit('ready');
   }
 }
 

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -73,8 +73,8 @@ var DELAY = 200;
 
 function Flo(dir, options, callback) {
   this.log = logger(options.verbose, 'Flo');
-  this.resolver = callback;
   this.dir = dir;
+  this.resolver = callback;
   this.server = new Server({
     port: options.port,
     host: options.host,

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -45,7 +45,8 @@ function flo(dir, options, callback) {
     useWatchman: options.useWatchman || false,
     useFilePolling: options.useFilePolling || false,
     pollingInterval: options.pollingInterval,
-    watchDotFiles: options.watchDotFiles || false
+    watchDotFiles: options.watchDotFiles || false,
+    disableWatcher: options.disableWatcher || false
   };
 
   callback = callback || noBuildCallback(dir);
@@ -78,9 +79,9 @@ function Flo(dir, options, callback) {
     host: options.host,
     log: logger(options.verbose, 'Server')
   });
+  this.dir = dir;
 
-  if (dir) {
-    this.dir = dir;
+  if (!options.disableWatcher) {
     this.watcher = new sane(dir, {
        glob: options.glob,
       poll: options.useFilePolling,

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -34,7 +34,7 @@ function flo(dir, options, callback) {
     options = null;
   }
 
-  dir = dir && path.resolve(dir);
+  dir = path.resolve(dir);
 
   options = options || {};
   options = {
@@ -74,12 +74,12 @@ var DELAY = 200;
 function Flo(dir, options, callback) {
   this.log = logger(options.verbose, 'Flo');
   this.resolver = callback;
+  this.dir = dir;
   this.server = new Server({
     port: options.port,
     host: options.host,
     log: logger(options.verbose, 'Server')
   });
-  this.dir = dir;
 
   if (!options.disableWatcher) {
     this.watcher = new sane(dir, {

--- a/lib/flo.js
+++ b/lib/flo.js
@@ -34,7 +34,7 @@ function flo(dir, options, callback) {
     options = null;
   }
 
-  dir = path.resolve(dir);
+  dir = dir && path.resolve(dir);
 
   options = options || {};
   options = {
@@ -72,8 +72,6 @@ var DELAY = 200;
 
 function Flo(dir, options, callback) {
   this.log = logger(options.verbose, 'Flo');
-  this.dir = dir;
-  this.realpathdir = fs.realpathSync(dir);
   this.resolver = callback;
   this.server = new Server({
     port: options.port,
@@ -81,16 +79,21 @@ function Flo(dir, options, callback) {
     log: logger(options.verbose, 'Server')
   });
 
-  this.watcher = new sane(dir, {
-    glob: options.glob,
-    poll: options.useFilePolling,
-    interval: options.pollingInterval,
-    watchman: options.useWatchman,
-    dot: options.watchDotFiles
-  });
-  this.watcher.on('change', this.onFileChange.bind(this));
-  this.watcher.on('ready', this.emit.bind(this, 'ready'));
-  this.watcher.on('error', this.emit.bind(this, 'error'));
+  if (dir) {
+    this.dir = dir;
+    this.watcher = new sane(dir, {
+       glob: options.glob,
+      poll: options.useFilePolling,
+      interval: options.pollingInterval,
+      watchman: options.useWatchman,
+      dot: options.watchDotFiles
+    });
+    this.watcher.on('change', this.onFileChange.bind(this));
+    this.watcher.on('ready', this.emit.bind(this, 'ready'));
+    this.watcher.on('error', this.emit.bind(this, 'error'));
+  } else {
+    this.emit('ready');
+  }
 }
 
 Flo.prototype.__proto__ = EventEmitter.prototype;


### PR DESCRIPTION
There are use cases when it is not desirable to start the file watcher, e.g. when integrating with other tools that have their own file watching mechanism in place.
One example is the [brunch fb-flo plugin](https://github.com/deliciousinsights/fb-flo-brunch).
It is way faster to use internal notifications than to wait for a second file system watcher process to notice the changes.
Please have a look [at my fork of fb-flo-brunch implementing this](https://github.com/istr/fb-flo/tree/nowatcher) for a real-live example.